### PR TITLE
move loader overload out of routes/ledgers/index

### DIFF
--- a/src/react/routes/ledgers/index.ts
+++ b/src/react/routes/ledgers/index.ts
@@ -5,17 +5,6 @@ import * as edit from './edit'
 import * as destroy from './destroy'
 import errorElement from '../error'
 import entries from './entries'
-import { redirect } from 'react-router-dom'
-import { getLedgers } from '../../data'
-import type { LoaderFunction } from '@remix-run/router'
-
-export const redirectToExisting: LoaderFunction = async (args): Promise<void | Response> => {
-  const ledgers = await getLedgers()
-  if (ledgers.length) {
-    return redirect(`/${ledgers[0]}`)
-  }
-  return newLedger.loader(args)
-}
 
 export default {
   ...root,
@@ -26,7 +15,6 @@ export default {
         {
           ...newLedger,
           index: true,
-          loader: redirectToExisting,
         },
         {
           ...newLedger,

--- a/src/react/routes/ledgers/new.tsx
+++ b/src/react/routes/ledgers/new.tsx
@@ -4,8 +4,12 @@ import type { ActionFunction, LoaderFunction } from '@remix-run/router'
 import { addLedger, getLedgers } from '../../data'
 import Form from './form'
 
-export const loader: LoaderFunction = async (): Promise<string[]> => {
-  return getLedgers()
+export const loader: LoaderFunction = async ({ request }): Promise<string[] | Response> => {
+  const ledgers = await getLedgers()
+  if (ledgers.length === 0 || /new$/.test(request.url)) {
+    return ledgers
+  }
+  return redirect(`/${ledgers[0]}`)
 }
 
 export const action: ActionFunction = async ({ request }) => {


### PR DESCRIPTION
I'm not sure which of these will cause more problems down the road.

In the new approach, `routes/ledgers/new.tsx` knows about which path
it's served from, duplicating this logic from `routes/ledgers/index`.

In the old approach, redirect logic was "hidden" inside a "secret
loader" in `routes/ledgers/index`. If someone goes looking for that
logic in the future, it might take a while to find.

Another option might be to `export const path` from all of these route
files, moving this logic entirely out of `routes/ledgers/index`. That
seems hard to look at, though--a benefit of keeping the `path` in the
index is that it's easy to look at and understand how all the routes
work together, rather than hiding literally all route information in
separate files.