### PR TITLE
include worker in build

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,25 +12,10 @@ export default defineConfig({
     build: {
       lib: {
         // Could also be a dictionary or array of multiple entry points
-        entry: {
-          googleWorker: new URL('src/data/backends/google/worker.ts', import.meta.url),
-        },
+        entry: new URL('src/data/backends/google/worker.ts', import.meta.url),
         formats: ['es'],
         // set fileName to, for example, `googleWorker.js`
-        fileName: (format, entryName) => `${entryName}.${format}`,
-      },
-      rollupOptions: {
-        // make sure to externalize deps that shouldn't be bundled
-        // into your library, like React (should be unnecessary for workers,
-        // since they don't import DOM stuff)
-        external: [],
-        output: {
-          // Provide global variables to use in the UMD build
-          // for externalized deps
-          // (again, probably not necessary for workers)
-          globals: {
-          },
-        },
+        fileName: 'googleWorker',
       },
     },
   },

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,5 +9,29 @@ export default defineConfig({
   integrations: [react()],
   vite: {
     sourcemap: true,
+    build: {
+      lib: {
+        // Could also be a dictionary or array of multiple entry points
+        entry: {
+          googleWorker: new URL('src/data/backends/google/worker.ts', import.meta.url),
+        },
+        formats: ['es'],
+        // set fileName to, for example, `googleWorker.js`
+        fileName: (format, entryName) => `${entryName}.${format}`,
+      },
+      rollupOptions: {
+        // make sure to externalize deps that shouldn't be bundled
+        // into your library, like React (should be unnecessary for workers,
+        // since they don't import DOM stuff)
+        external: [],
+        output: {
+          // Provide global variables to use in the UMD build
+          // for externalized deps
+          // (again, probably not necessary for workers)
+          globals: {
+          },
+        },
+      },
+    },
   },
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,8 +8,8 @@ export default defineConfig({
   site: 'https://new.entire.life',
   integrations: [react()],
   vite: {
-    sourcemap: true,
     build: {
+      sourcemap: true,
       lib: {
         // Could also be a dictionary or array of multiple entry points
         entry: new URL('src/data/backends/google/worker.ts', import.meta.url),


### PR DESCRIPTION
The worker.ts file is not currently being included in the built files that get output to `dist`

This attempts to fix that. Not working yet.